### PR TITLE
Update Dockerfile with nginx hardened image (0 CVEs)

### DIFF
--- a/cts/nginx/Dockerfile
+++ b/cts/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM cgr.dev/chainguard/nginx:latest
 
 ARG HOSTNAME
 


### PR DESCRIPTION
Updated the **Dockerfile nginx container image**. Instead, we recommend using the latest **Chainguard nginx container image, which is free to use, hardened daily, and actively maintained to eliminate CVEs by patching both direct and transitive dependencies.**

 Recommend using Chainguard's nginx:latest image that is patched daily, 0 CVEs, the transition should be straightforward—and will significantly reduce software supply chain risk and attack surface.

See the difference: https://images.chainguard.dev/directory/image/nginx/compare
<img width="1193" alt="Screenshot 2025-05-20 at 2 21 57 PM" src="https://github.com/user-attachments/assets/fc30f99b-be69-410c-a9c6-4cd222b8f198" />

Docker
~ grype nginx:alpine
✔ Pulled image
✔ Loaded image nginx:alpine
✔ Parsed image sha256:96868d9fa38f469a86d2f25787e43ee9ad330339d30be260aa9f5a338bb03751
✔ Cataloged contents 4ea77aed1105f06c21b41d8ebcbfbcaa11e6ce07461b8b3bbcee3d70de786b00
├── ✔ Packages [68 packages]
├── ✔ File metadata [978 locations]
├── ✔ Executables [123 executables]
└── ✔ File digests [978 files]
**✔ Scanned for vulnerabilities [12 vulnerability matches]
├── by severity: 0 critical, 3 high, 3 medium, 6 low, 0 negligible
└── by status: 2 fixed, 10 not-fixed, 0 ignored**

NAME INSTALLED FIXED-IN TYPE VULNERABILITY SEVERITY EPSS% RISK
tiff 4.7.0-r0 apk https://github.com/advisories/GHSA-fq8g-55cp-756j Medium 60.80 0.2
tiff 4.7.0-r0 apk https://github.com/advisories/GHSA-cx8g-4cf5-cjv3 High 49.60 0.2
tiff 4.7.0-r0 apk https://github.com/advisories/GHSA-2j29-7372-8rgg Medium 45.05 0.1
libxml2 2.13.4-r5 2.13.4-r6 apk https://github.com/advisories/GHSA-w8fw-fj9q-vcjj High 3.78 < 0.1
libxml2 2.13.4-r5 2.13.4-r6 apk https://github.com/advisories/GHSA-mfrm-w63c-3x58 High 1.83 < 0.1
tiff 4.7.0-r0 apk https://github.com/advisories/GHSA-4v5g-xjvw-59g6 Medium 2.66 < 0.1
busybox 1.37.0-r12 apk https://github.com/advisories/GHSA-wp4q-9jq4-gv74 Low 2.25 < 0.1
busybox-binsh 1.37.0-r12 apk https://github.com/advisories/GHSA-wp4q-9jq4-gv74 Low 2.25 < 0.1
ssl_client 1.37.0-r12 apk https://github.com/advisories/GHSA-wp4q-9jq4-gv74 Low 2.25 < 0.1
busybox 1.37.0-r12 apk https://github.com/advisories/GHSA-rrv5-483w-xmr9 Low 3.11 < 0.1
busybox-binsh 1.37.0-r12 apk https://github.com/advisories/GHSA-rrv5-483w-xmr9 Low 3.11 < 0.1
ssl_client 1.37.0-r12 apk https://github.com/advisories/GHSA-rrv5-483w-xmr9 Low 3.11 < 0.1

Chainguard
~ grype cgr.dev/chainguard/nginx:latest
✔ Loaded image cgr.dev/chainguard/nginx:latest
✔ Parsed image sha256:989aaf169ed087c46f7ef49d9bcc6c83eebb550ac1b69e379406926feb3232db
✔ Cataloged contents 65b84f245ad3d56efb85362bf4fb83e7ec82b1104ccfeaed8e2c89050c901751
├── ✔ Packages [16 packages]
├── ✔ Executables [33 executables]
├── ✔ File metadata [165 locations]
└── ✔ File digests [165 files]
**✔ Scanned for vulnerabilities [0 vulnerability matches]
├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
└── by status: 0 fixed, 0 not-fixed, 0 ignored**
No vulnerabilities found